### PR TITLE
fix: add details and role in query

### DIFF
--- a/models/mariadb/user.ts
+++ b/models/mariadb/user.ts
@@ -17,7 +17,15 @@ export interface UserModelInterface {
 const prisma = new PrismaClient()
 export default class UserModel {
   static getAll = async () => {
-    const users = await prisma.user_accounts.findMany()
+    const users = await prisma.user_accounts.findMany({
+      include: {
+        user_details: {
+          include: {
+            role: true
+          }
+        }
+      }
+    })
     const usersWithoutPassword = users.map((user) =>
       omitFields(user, ["password"])
     )


### PR DESCRIPTION
-- add detail and roles in query getAll
```
static getAll = async () => {
    const users = await prisma.user_accounts.findMany({
      include: {
        user_details: {
          include: {
            role: true
          }
        }
      }
    })
    const usersWithoutPassword = users.map((user) =>
      omitFields(user, ["password"])
    )
    return usersWithoutPassword
  }
```
